### PR TITLE
Add Fn key push-to-talk and improve accessibility flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Ramblr.xcodeproj/project.xcworkspace/xcuserdata/chris.xcuserdatad/UserInterfaceState.xcuserstate
+Ramblr.xcodeproj/xcuserdata/chris.xcuserdatad/xcschemes/xcschememanagement.plist

--- a/Ramblr/MenuBarView.swift
+++ b/Ramblr/MenuBarView.swift
@@ -8,7 +8,7 @@ struct MenuBarView: View {
     @ObservedObject var coordinator: RecordingCoordinator
     @State private var apiKey: String = UserDefaults.standard.string(forKey: "OpenAIAPIKey") ?? ""
     @State private var groqApiKey: String = UserDefaults.standard.string(forKey: "GroqAPIKey") ?? ""
-    @State private var autoPasteEnabled: Bool = (UserDefaults.standard.object(forKey: "AutoPasteEnabled") as? Bool) ?? false
+    @State private var autoPasteEnabled: Bool = (UserDefaults.standard.object(forKey: "AutoPasteEnabled") as? Bool) ?? true
     @State private var showHotkeyChangePopover: Bool = false
     @State private var showCancelHotkeyChangePopover: Bool = false
     
@@ -310,6 +310,7 @@ struct MenuBarView: View {
         .onAppear {
             // Refresh accessibility status whenever the menu opens
             transcriptionManager.checkAccessibilityPermission(shouldPrompt: false)
+            hotkeyManager.checkPermissions()
         }
         // Detached panel used instead of sheets for key entry (prevents menu dismissal)
     }

--- a/Ramblr/RamblrApp.swift
+++ b/Ramblr/RamblrApp.swift
@@ -5,10 +5,6 @@ import UserNotifications
 class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         logInfo("Application did finish launching")
-        // Just ensure we're not active
-        if NSApp.isActive {
-            NSApp.deactivate()
-        }
         // Ensure notifications show while app is active/agent
         UNUserNotificationCenter.current().delegate = self
     }
@@ -22,6 +18,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
                                 willPresent notification: UNNotification,
                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.banner, .list, .sound])
+    }
+    
+    // Handle notification clicks
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+        if response.notification.request.content.userInfo["action"] as? String == "open_accessibility" {
+            logInfo("User clicked accessibility notification")
+            if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
+                NSWorkspace.shared.open(url)
+            }
+        }
+        completionHandler()
     }
 }
 

--- a/Ramblr/RecordingCoordinator.swift
+++ b/Ramblr/RecordingCoordinator.swift
@@ -49,6 +49,26 @@ class RecordingCoordinator: ObservableObject {
             logDebug("RecordingCoordinator: Received cancel hotkey notification")
             self?.cancelRecording()
         }
+        
+        // Observe explicit start recording notification (for push-to-talk)
+        NotificationCenter.default.addObserver(
+            forName: NSNotification.Name("StartRecording"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            logDebug("RecordingCoordinator: Received StartRecording notification")
+            self?.startRecordingSession()
+        }
+        
+        // Observe explicit stop recording notification (for push-to-talk)
+        NotificationCenter.default.addObserver(
+            forName: NSNotification.Name("StopRecording"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            logDebug("RecordingCoordinator: Received StopRecording notification")
+            self?.stopRecordingSession()
+        }
     }
     
     @objc private func updateTranscriptionStatus(_ notification: Notification) {
@@ -104,41 +124,61 @@ class RecordingCoordinator: ObservableObject {
         logInfo("RecordingCoordinator: toggleRecording called, current state: \(audioManager.isRecording)")
         
         if audioManager.isRecording {
-            logInfo("RecordingCoordinator: Stopping recording...")
+            stopRecordingSession()
+        } else {
+            startRecordingSession()
+        }
+    }
+    
+    // Explicit start method
+    private func startRecordingSession() {
+        guard !audioManager.isRecording else {
+            logInfo("RecordingCoordinator: Already recording, ignoring start request")
+            return
+        }
+        
+        logInfo("RecordingCoordinator: Starting recording session...")
+        audioManager.startRecording()
+        
+        // Show waveform indicator
+        WaveformIndicatorWindow.shared.showWaveform()
+    }
+    
+    // Explicit stop method
+    private func stopRecordingSession() {
+        guard audioManager.isRecording else {
+            logInfo("RecordingCoordinator: Not recording, ignoring stop request")
+            return
+        }
+        
+        logInfo("RecordingCoordinator: Stopping recording session...")
+        
+        if let recordingURL = audioManager.stopRecording() {
+            logInfo("RecordingCoordinator: Got recording URL: \(recordingURL)")
+            self.lastRecordingURL = recordingURL // Save for potential retry
+            logInfo("Recording completed: \(recordingURL.lastPathComponent)")
             
-            if let recordingURL = audioManager.stopRecording() {
-                logInfo("RecordingCoordinator: Got recording URL: \(recordingURL)")
-                self.lastRecordingURL = recordingURL // Save for potential retry
-                logInfo("Recording completed: \(recordingURL.lastPathComponent)")
-                
-                // Verify the file exists and has data
-                if let fileSize = try? FileManager.default.attributesOfItem(atPath: recordingURL.path)[.size] as? Int64 {
-                    logInfo("RecordingCoordinator: Recording file size: \(fileSize) bytes")
-                    if fileSize > 0 {
-                        // Switch to transcribing mode
-                        WaveformIndicatorWindow.shared.showTranscribing()
-                        transcribeAudio(recordingURL: recordingURL)
-                    } else {
-                        logError("RecordingCoordinator: Recording file is empty")
-                        WaveformIndicatorWindow.shared.hide()
-                        showRecordingError()
-                    }
+            // Verify the file exists and has data
+            if let fileSize = try? FileManager.default.attributesOfItem(atPath: recordingURL.path)[.size] as? Int64 {
+                logInfo("RecordingCoordinator: Recording file size: \(fileSize) bytes")
+                if fileSize > 0 {
+                    // Switch to transcribing mode
+                    WaveformIndicatorWindow.shared.showTranscribing()
+                    transcribeAudio(recordingURL: recordingURL)
                 } else {
-                    logError("RecordingCoordinator: Could not get recording file size")
+                    logError("RecordingCoordinator: Recording file is empty")
                     WaveformIndicatorWindow.shared.hide()
                     showRecordingError()
                 }
             } else {
-                // Don't show an error - this is likely an intentionally short or silent recording
-                logInfo("RecordingCoordinator: Recording was too short or silent")
+                logError("RecordingCoordinator: Could not get recording file size")
                 WaveformIndicatorWindow.shared.hide()
+                showRecordingError()
             }
         } else {
-            logInfo("RecordingCoordinator: Starting recording...")
-            audioManager.startRecording()
-            
-            // Show waveform indicator
-            WaveformIndicatorWindow.shared.showWaveform()
+            // Don't show an error - this is likely an intentionally short or silent recording
+            logInfo("RecordingCoordinator: Recording was too short or silent")
+            WaveformIndicatorWindow.shared.hide()
         }
     }
     


### PR DESCRIPTION
Implements push-to-talk recording using the Fn key by monitoring modifier flags globally and locally, and dispatching notifications to start/stop recording. Refactors RecordingCoordinator to handle explicit start/stop recording notifications. Changes auto-paste default to enabled, improves clipboard handling for pasting, and replaces accessibility alerts with actionable notifications that open System Settings. Also adds .gitignore for user-specific Xcode files.

Fix for #6 